### PR TITLE
feat: improve dnscheck by adding IPAddr and HTTP3 hints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+
+[*.json]
+indent_style = space
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/json-syntax-and-input-check.yml
+++ b/.github/workflows/json-syntax-and-input-check.yml
@@ -26,9 +26,10 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs multi-line command using the runners shell
-      - name: check json syntax 
-        run: jq -e -r . -C ooni.json
-      
+      - name: check json syntax
+        run: |
+          jq -e -r . -C ooni.json
+
       # Runs multi-line command using the runners shell
-      - name: check duplicate inputs 
+      - name: check duplicate inputs
         run: ./scripts/rejectdups.py ooni.json

--- a/.github/workflows/json-syntax-and-input-check.yml
+++ b/.github/workflows/json-syntax-and-input-check.yml
@@ -27,12 +27,8 @@ jobs:
 
       # Runs multi-line command using the runners shell
       - name: check json syntax 
-        run: |
-          jq -e -r . -C ooni.json
-          exit $?
+        run: jq -e -r . -C ooni.json
       
       # Runs multi-line command using the runners shell
       - name: check duplicate inputs 
-        run: |
-          dup_lines=`jq -r '.nettests[].inputs[]?' ooni.json | sort | uniq -d`
-          if [ "$dup_lines" != "" ] && [ $(echo -n "$dup_lines" | wc -l) -gt 0 ];then echo "$dup_lines";exit 1;else echo "nothing"; fi
+        run: ./scripts/rejectdups.py ooni.json

--- a/.github/workflows/json-syntax-and-input-check.yml
+++ b/.github/workflows/json-syntax-and-input-check.yml
@@ -26,10 +26,9 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs multi-line command using the runners shell
-      - name: check json syntax
-        run: |
-          jq -e -r . -C ooni.json
-
+      - name: check json syntax 
+        run: jq -e -r . -C ooni.json
+      
       # Runs multi-line command using the runners shell
-      - name: check duplicate inputs
+      - name: check duplicate inputs 
         run: ./scripts/rejectdups.py ooni.json

--- a/ooni.json
+++ b/ooni.json
@@ -265,7 +265,6 @@
                 "https://smp-device-content.apple.com/robots.txt",
                 "https://doh.dns.apple.com/dns-query?dns=q80BAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB",
                 "https://guzzoni.apple.com/robots.txt",
-                "https://sandbox.itunes.apple.com/robots.txt",
                 "https://www.example.org/"
             ],
             "test_name": "web_connectivity@v0.5"

--- a/ooni.json
+++ b/ooni.json
@@ -1,4 +1,4 @@
-
+{
     "name": "hidden-censorship",
     "description": "Wikicensorship's custom OONI Run v2 descriptor",
     "author": "github.com/wikicensorship",

--- a/ooni.json
+++ b/ooni.json
@@ -1,4 +1,4 @@
-{
+
     "name": "hidden-censorship",
     "description": "Wikicensorship's custom OONI Run v2 descriptor",
     "author": "github.com/wikicensorship",

--- a/ooni.json
+++ b/ooni.json
@@ -277,6 +277,493 @@
             "test_name": "stunreachability"
         },
         {
+            "inputs": [
+                "https://dns.google/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "8.8.4.4 8.8.8.8 2001:4860:4860::8844 2001:4860:4860::8888",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.google/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "8.8.4.4 8.8.8.8 2001:4860:4860::8844 2001:4860:4860::8888",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://8.8.8.8/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://8.8.8.8/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://8.8.8.8:853/"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://8.8.4.4:853/"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://8.8.4.4/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "104.16.248.249 104.16.249.249 2606:4700::6810:f8f9 2606:4700::6810:f9f9",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "104.16.248.249 104.16.249.249 2606:4700::6810:f8f9 2606:4700::6810:f9f9",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1.1.1.1/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1.1.1.1/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1.0.0.1/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1.0.0.1/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://1.1.1.1:853/"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://1.0.0.1:853/"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.9 149.112.112.112 2620:fe::9 2620:fe::fe",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://9.9.9.9/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://9.9.9.9:853/"
+            ],
+            "options": {
+                "DefaultAddrs": "",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns.quad9.net/"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.9 149.112.112.112 2620:fe::fe 2620:fe::9",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://family.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.3 1.0.0.3 2606:4700:4700::1113 2606:4700:4700::1003",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://family.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.3 1.0.0.3 2606:4700:4700::1113 2606:4700:4700::1003",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://family.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.3 1.0.0.3 2606:4700:4700::1003 2606:4700:4700::1113",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns11.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "149.112.112.11 9.9.9.11 2620:fe::fe:11 2620:fe::11",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns11.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.11 149.112.112.11 2620:fe::fe:11 2620:fe::11",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns9.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.9 149.112.112.9 2620:fe::fe:9 2620:fe::9",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns9.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.9 149.112.112.9 2620:fe::fe:9 2620:fe::9",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns12.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.12 149.112.112.12 2620:fe::fe:12 2620:fe::12",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns12.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "149.112.112.12 9.9.9.12 2620:fe::fe:12 2620:fe::12",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1dot1dot1dot1.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://1dot1dot1dot1.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001",
+                "HTTP3Enabled": true
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://1dot1dot1dot1.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.0.0.1 1.1.1.1 2606:4700:4700::1111 2606:4700:4700::1001",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.adguard.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "94.140.14.14 94.140.15.15 2a10:50c0::ad2:ff 2a10:50c0::ad1:ff",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns.adguard.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "94.140.15.15 94.140.14.14 2a10:50c0::ad2:ff 2a10:50c0::ad1:ff",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns-family.adguard.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "94.140.14.15 94.140.15.16 2a10:50c0::bad2:ff 2a10:50c0::bad1:ff",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns-family.adguard.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "94.140.14.15 94.140.15.16 2a10:50c0::bad1:ff 2a10:50c0::bad2:ff",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.cloudflare.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "104.16.132.229 104.16.133.229 2606:4700::6810:84e5 2606:4700::6810:85e5",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://adblock.doh.mullvad.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "194.242.2.3 2a07:e340::3",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://adblock.doh.mullvad.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "194.242.2.3 2a07:e340::3",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.alidns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "223.5.5.5 223.6.6.6 2400:3200::1 2400:3200:baba::1",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns.alidns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "223.5.5.5 223.6.6.6 2400:3200::1 2400:3200:baba::1",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://doh.opendns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "146.112.41.2 2620:119:fc::2",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.nextdns.io/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "192.145.127.148 178.255.155.63 2a0d:5642:112:101:5054:ff:fee6:f5d4 2a00:11c0:b:350::3",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns.nextdns.io/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "192.145.127.148 178.255.155.63 2a00:11c0:b:350::3 2a0d:5642:112:101:5054:ff:fee6:f5d4",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns10.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "9.9.9.10 149.112.112.10 2620:fe::fe:10 2620:fe::10",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns10.quad9.net/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "149.112.112.10 9.9.9.10 2620:fe::10 2620:fe::fe:10",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://security.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.0.0.2 1.1.1.2 2606:4700:4700::1112 2606:4700:4700::1002",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://security.cloudflare-dns.com/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "1.1.1.2 1.0.0.2 2606:4700:4700::1112 2606:4700:4700::1002",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "https://dns.switch.ch/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "130.59.31.251 130.59.31.248 2001:620:0:ff::2 2001:620:0:ff::3",
+                "HTTP3Enabled": false
+            },
+            "test_name": "dnscheck"
+        },
+        {
+            "inputs": [
+                "dot://dns.switch.ch/dns-query"
+            ],
+            "options": {
+                "DefaultAddrs": "130.59.31.251 130.59.31.248 2001:620:0:ff::3 2001:620:0:ff::2",
+                "HTTP3Enabled": false
+            },
             "test_name": "dnscheck"
         }
     ]

--- a/scripts/dnscheck.py
+++ b/scripts/dnscheck.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+"""
+This script takes in input a single file containing a list of DoT/DoH
+endpoint URLs to be measured and outputs a list of JSON entries suitable
+for testing those endpoints using dnscheck and OONI Run v2.
+"""
+
+import ipaddress
+import sys
+import json
+from urllib.parse import urlsplit, urlencode, urlunparse
+from urllib.request import urlopen
+
+
+def calldohwithtype(domain, type):
+    out = []
+    scheme = "https"
+    hostname = "dns.google"
+    path = "/resolve"
+    params = {
+        "name": domain,
+        "type": type,
+    }
+    query_string = urlencode(params)
+    dohurl = urlunparse((scheme, hostname, path, "", query_string, ""))
+    sys.stderr.write(f"DNS: lookup {dohurl}...\n")
+    with urlopen(dohurl) as httpresp:
+        data = httpresp.read()
+        response = json.loads(data)
+        for answer in response["Answer"]:
+            atype = answer["type"]
+            if (atype == 1 and type == "A") or (atype == 28 and type == "AAAA"):
+                out.append(answer["data"])
+    return out
+
+
+def calldoh(domain):
+    out = []
+    out.extend(calldohwithtype(domain, "A"))
+    out.extend(calldohwithtype(domain, "AAAA"))
+    return " ".join(out)
+
+
+def newentries(input_url):
+    supports_quic = set(
+        [
+            "dns.google",
+            "8.8.8.8",
+            "cloudflare-dns.com",
+            "1.1.1.1",
+            "1.0.0.1",
+            "family.cloudflare-dns.com",
+            "1dot1dot1dot1.cloudflare-dns.com",
+        ]
+    )
+
+    default_addrs = ""
+    parsed_url = urlsplit(input_url)
+
+    try:
+        ipaddress.ip_address(str(parsed_url.hostname))
+    except ValueError:
+        default_addrs = calldoh(parsed_url.hostname)
+
+    yield {
+        "inputs": [
+            input_url,
+        ],
+        "options": {
+            "DefaultAddrs": default_addrs,
+            "HTTP3Enabled": False,
+        },
+        "test_name": "dnscheck",
+    }
+
+    if parsed_url.scheme == "https" and parsed_url.hostname in supports_quic:
+        yield {
+            "inputs": [
+                input_url,
+            ],
+            "options": {
+                "DefaultAddrs": default_addrs,
+                "HTTP3Enabled": True,
+            },
+            "test_name": "dnscheck",
+        }
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: ./script/dnscheck.py FILE")
+
+    entries = []
+    with open(sys.argv[1], "r") as infp:
+        for line in infp:
+            line = line.strip()
+            for entry in newentries(line):
+                entries.append(entry)
+
+    json.dump(entries, sys.stdout, indent="    ")
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rejectdups.py
+++ b/scripts/rejectdups.py
@@ -39,7 +39,7 @@ def dnscheck(descr):
             continue
         http3_enabled = nettest.get("options", {}).get("HTTP3Enabled", False)
         for input in nettest["inputs"]:
-            print(f"[dnscheck] checking {input} http3_enabled={http3_enabled}...")
+            print(f"[dnscheck] checking {input} for http3_enabled={http3_enabled}...")
             if http3_enabled:
                 if input in urls["http3"]:
                     raise RuntimeError(

--- a/scripts/rejectdups.py
+++ b/scripts/rejectdups.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+"""
+Takes in input an OONI Run v2 descriptor and returns an error in case in
+which we are testing duplicate inputs or endpoints.
+
+We do not consider the input duplicate if different nettests are testing
+the same or a similar input source.
+
+We do not consider the input duplicate when we're using HTTP3 and TCP/TLS
+for the same input, since those are distinct measurements.
+"""
+
+import json
+import sys
+
+
+def webconnectivity(descr):
+    urls = set()
+    for nettest in descr["nettests"]:
+        if nettest["test_name"] not in set(
+            ["web_connectivity", "web_connectivity@v0.5"]
+        ):
+            continue
+        for input in nettest["inputs"]:
+            print(f"[web_connectivity] checking {input}...")
+            if input in urls:
+                raise RuntimeError(f"[web_connectivity] input {input} already present")
+            urls.add(input)
+
+
+def dnscheck(descr):
+    urls = {
+        "http3": set(),
+        "otherwise": set(),
+    }
+    for nettest in descr["nettests"]:
+        if nettest["test_name"] != "dnscheck":
+            continue
+        http3_enabled = nettest.get("options", {}).get("HTTP3Enabled", False)
+        for input in nettest["inputs"]:
+            print(f"[dnscheck] checking {input} http3_enabled={http3_enabled}...")
+            if http3_enabled:
+                if input in urls["http3"]:
+                    raise RuntimeError(
+                        f"[dnscheck] input {input} already present for http3_enabled={http3_enabled}"
+                    )
+                urls["http3"].add(input)
+            else:
+                if input in urls["otherwise"]:
+                    raise RuntimeError(
+                        f"[dnscheck] input {input} already present for http3_enabled={http3_enabled}"
+                    )
+                urls["otherwise"].add(input)
+
+
+def checkdescr(descr):
+    webconnectivity(descr)
+    dnscheck(descr)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: ./script/dnscheck.py FILE")
+
+    with open(sys.argv[1], "r") as infp:
+        descr = json.load(infp)
+        checkdescr(descr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds better `dnscheck` support by specifying default addrs for the domain and adding HTTP/3 hints where we know a priori that a DoH service supports HTTP/3.

While there:

* add `.editorconfig` so we make sure we don't screw up `ooni.json` formatting
* add the basic-script I used to improve the `dnscheck` input list